### PR TITLE
handle sending group SMS

### DIFF
--- a/sample/src/main/java/com/klinker/android/messaging_sample/MainActivity.java
+++ b/sample/src/main/java/com/klinker/android/messaging_sample/MainActivity.java
@@ -197,7 +197,7 @@ public class MainActivity extends Activity {
                     message.setImage(BitmapFactory.decodeResource(getResources(), R.drawable.android));
                 }
 
-                transaction.sendNewMessage(message, Transaction.NO_THREAD_ID);
+                transaction.sendNewMessage(message);
             }
         }).start();
     }


### PR DESCRIPTION
# Notes
- handle sending SMS to multiple participants (group SMS)
- a dummy broadcast message is sent to a new address built by joining the addresses in the group with a space (" ")
    - for example, if the participants of the group SMS are `[1111, 2222, 3333]`, the group SMS would be sent to an address `"1111 2222 3333"`.
    - this is similar to how it is implemented on the [AOSP Messenger app](https://github.com/alperali/Messaging/blob/goplay/app/src/main/java/com/android/messaging/datamodel/action/InsertNewMessageAction.java#L158-L174).
- remove parameter `threadId` from `Transaction.sendNewMessage` method, this method would now get or create the thread id based on the address(es)