### PR TITLE
Persist sub id when sending an sms

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -972,6 +972,6 @@ public class Transaction {
     }
 
     public static String getAddressSeparator() {
-        return "\\|";
+        return "|";
     }
 }

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -279,15 +279,21 @@ public class Transaction {
 
             Calendar cal = Calendar.getInstance();
             ContentValues values = new ContentValues();
-            values.put("address", address);
-            values.put("body", settings.getStripUnicode() ? StripAccents.stripAccents(text) : text);
-            values.put("date", cal.getTimeInMillis() + "");
-            values.put("read", 1);
-            values.put("type", 4);
+            values.put(Telephony.Sms.ADDRESS, address);
+            values.put(Telephony.Sms.BODY, settings.getStripUnicode() ? StripAccents.stripAccents(text) : text);
+            values.put(Telephony.Sms.DATE, cal.getTimeInMillis() + "");
+            values.put(Telephony.Sms.READ, 1);
+            values.put(Telephony.Sms.TYPE, 4);
+
+            // insert subscription id only if it is a valid one.
+            int subscriptionId = settings.getSubscriptionId();
+            if (Settings.DEFAULT_SUBSCRIPTION_ID != subscriptionId) {
+                values.put(Telephony.Sms.SUBSCRIPTION_ID, subscriptionId);
+            }
 
             Log.v("send_transaction", "saving message with thread id: " + threadId);
 
-            values.put("thread_id", threadId);
+            values.put(Telephony.Sms.THREAD_ID, threadId);
             messageUri = context.getContentResolver().insert(Uri.parse("content://sms/"), values);
 
             Log.v("send_transaction", "inserted to uri: " + messageUri);


### PR DESCRIPTION
On some strange devices, the subscription id must be persisted before the message is sent using SMS manager API. Updating the subscription id after that throws a column not found error.

Before this change, `android-smsmms` only persisted the sub id when sending an MMS message. 

related links:
- https://stackoverflow.com/questions/71103030/how-do-get-sim-slot-index-of-inbox-sms-in-android-by-contentprovider
 - https://cs.android.com/android/platform/superproject/+/master:packages/apps/Messaging/src/com/android/messaging/sms/MmsUtils.java;l=873