### PR TITLE
Target SDK 34

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,11 +7,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 22
-        targetSdkVersion 31
+        targetSdkVersion 34
     }
 
     lintOptions {

--- a/library/src/main/java/com/android/mms/transaction/DownloadManager.java
+++ b/library/src/main/java/com/android/mms/transaction/DownloadManager.java
@@ -68,7 +68,8 @@ public class DownloadManager {
                 .scheme(ContentResolver.SCHEME_CONTENT)
                 .build();
 
-        Intent download = new Intent(receiver.mAction);
+        Intent download = new Intent(context.getApplicationContext(), MmsDownloadReceiver.class);
+        download.setAction(receiver.mAction);
         download.putExtra(MmsReceivedReceiver.EXTRA_FILE_PATH, mDownloadFile.getPath());
         download.putExtra(MmsReceivedReceiver.EXTRA_LOCATION_URL, location);
         download.putExtra(MmsReceivedReceiver.EXTRA_TRANSACTION_ID, transactionId);

--- a/library/src/main/java/com/android/mms/transaction/DownloadManager.java
+++ b/library/src/main/java/com/android/mms/transaction/DownloadManager.java
@@ -51,7 +51,13 @@ public class DownloadManager {
         mMap.put(location, receiver);
 
         // Use unique action in order to avoid cancellation of notifying download result.
-        context.getApplicationContext().registerReceiver(receiver, new IntentFilter(receiver.mAction));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            context.getApplicationContext().registerReceiver(
+                    receiver, new IntentFilter(receiver.mAction), Context.RECEIVER_NOT_EXPORTED
+            );
+        } else {
+            context.getApplicationContext().registerReceiver(receiver, new IntentFilter(receiver.mAction));
+        }
 
         Log.v(TAG, "receiving with system method");
         final String fileName = "download." + Math.abs(new Random().nextLong()) + ".dat";
@@ -61,6 +67,7 @@ public class DownloadManager {
                 .path(fileName)
                 .scheme(ContentResolver.SCHEME_CONTENT)
                 .build();
+
         Intent download = new Intent(receiver.mAction);
         download.putExtra(MmsReceivedReceiver.EXTRA_FILE_PATH, mDownloadFile.getPath());
         download.putExtra(MmsReceivedReceiver.EXTRA_LOCATION_URL, location);

--- a/library/src/main/java/com/android/mms/util/RateController.java
+++ b/library/src/main/java/com/android/mms/util/RateController.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.database.sqlite.SqliteWrapper;
+import android.os.Build;
 import android.provider.Telephony.Mms.Rate;
 
 import com.android.mms.logs.LogTag;
@@ -36,15 +37,15 @@ public class RateController {
     private static final int RATE_LIMIT = 100;
     private static final long ONE_HOUR = 1000 * 60 * 60;
 
-    private static final int NO_ANSWER  = 0;
+    private static final int NO_ANSWER = 0;
     private static final int ANSWER_YES = 1;
-    private static final int ANSWER_NO  = 2;
+    private static final int ANSWER_NO = 2;
 
     public static final int ANSWER_TIMEOUT = 20000;
     public static final String RATE_LIMIT_SURPASSED_ACTION =
-        "com.android.mms.RATE_LIMIT_SURPASSED";
+            "com.android.mms.RATE_LIMIT_SURPASSED";
     public static final String RATE_LIMIT_CONFIRMED_ACTION =
-        "com.android.mms.RATE_LIMIT_CONFIRMED";
+            "com.android.mms.RATE_LIMIT_CONFIRMED";
 
     private static RateController sInstance;
     private static boolean sMutexLock;
@@ -62,7 +63,7 @@ public class RateController {
             if (RATE_LIMIT_CONFIRMED_ACTION.equals(intent.getAction())) {
                 synchronized (this) {
                     mAnswer = intent.getBooleanExtra("answer", false)
-                                            ? ANSWER_YES : ANSWER_NO;
+                            ? ANSWER_YES : ANSWER_NO;
                     notifyAll();
                 }
             }
@@ -96,13 +97,13 @@ public class RateController {
         ContentValues values = new ContentValues(1);
         values.put(Rate.SENT_TIME, System.currentTimeMillis());
         SqliteWrapper.insert(mContext, mContext.getContentResolver(),
-                             Rate.CONTENT_URI, values);
+                Rate.CONTENT_URI, values);
     }
 
     public final boolean isLimitSurpassed() {
         long oneHourAgo = System.currentTimeMillis() - ONE_HOUR;
         Cursor c = SqliteWrapper.query(mContext, mContext.getContentResolver(),
-                Rate.CONTENT_URI, new String[] { "COUNT(*) AS rate" },
+                Rate.CONTENT_URI, new String[]{"COUNT(*) AS rate"},
                 Rate.SENT_TIME + ">" + oneHourAgo, null, null);
         if (c != null) {
             try {
@@ -123,13 +124,19 @@ public class RateController {
             try {
                 wait();
             } catch (InterruptedException e) {
-                 // Ignore it.
+                // Ignore it.
             }
         }
         sMutexLock = true;
 
-        mContext.registerReceiver(mBroadcastReceiver,
-                new IntentFilter(RATE_LIMIT_CONFIRMED_ACTION));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            mContext.getApplicationContext().registerReceiver(
+                    mBroadcastReceiver, new IntentFilter(RATE_LIMIT_CONFIRMED_ACTION), Context.RECEIVER_EXPORTED
+            );
+        } else {
+            mContext.registerReceiver(mBroadcastReceiver,
+                    new IntentFilter(RATE_LIMIT_CONFIRMED_ACTION));
+        }
 
         mAnswer = NO_ANSWER;
         try {
@@ -154,7 +161,7 @@ public class RateController {
                 }
                 wait(1000L);
             } catch (InterruptedException e) {
-                 // Ignore it.
+                // Ignore it.
             }
         }
         return mAnswer;


### PR DESCRIPTION
### Notes/Changes: 
 - Use `RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED` flag when registering receivers on UpsideDownCake and above. Whenever it wasn't clear, I used `RECEIVER_EXPORTED` to avoid digging too much into MMS-related code (half of the MMS stuff is not used anyway).
 - Use explicit pending intent when downloading MMS messages.
 - [Context-registered broadcasts are queued while apps are cached](https://developer.android.com/about/versions/14/behavior-changes-all#pending-broadcasts-queued): This may or may not delay downloading of MMS messages but given that the default SMS app is supposed to keep running, I don't think we need to do anything about this.  